### PR TITLE
feat(renderers): prepare for upstream inclusion.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,23 @@
 
 'use strict';
 
+var legacyPaths = {};
+
 module.exports = {
-    FileRenderer: require('./lib/file'),
-    AssertionRenderer: require('./lib/assertion'),
-    DiagramRenderer: require('./lib/diagram'),
-    BinaryExpressionRenderer: require('./lib/binary-expression'),
-    SuccinctRenderer: require('./lib/succinct-diagram')
+    FileRenderer: legacy('file', require('./lib/file')),
+    AssertionRenderer: legacy('assertion', require('./lib/assertion')),
+    DiagramRenderer: legacy('diagram', require('./lib/diagram')),
+    BinaryExpressionRenderer: legacy('binary-expression', require('./lib/binary-expression')),
+    SuccinctRenderer: legacy('succinct-diagram', require('./lib/succinct-diagram'))
+};
+
+function legacy(path, val) {
+    return legacyPaths['./built-in/' + path] = val;
+}
+
+module.exports.lookup = function (path) {
+    if (typeof path === 'string') {
+        return legacyPaths[path] || require(path);
+    }
+    return path;
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "array-foreach": "^1.0.1",
     "array-some": "^1.0.0",
     "object-keys": "^1.0.0",
-    "type-name": "^1.0.1"
+    "type-name": "^1.1.0"
   },
   "devDependencies": {
     "ava": "^0.3.0",

--- a/test/legacy-paths-test.js
+++ b/test/legacy-paths-test.js
@@ -1,0 +1,12 @@
+import test from 'ava';
+import baseAssert from 'assert';
+import renderers, {lookup} from '../index';
+
+test('lookup()', t => {
+  t.ok(lookup('./built-in/assertion') === renderers.AssertionRenderer);
+  t.ok(lookup('./built-in/binary-expression') === renderers.BinaryExpressionRenderer);
+  t.ok(lookup('./built-in/diagram') === renderers.DiagramRenderer);
+  t.ok(lookup('./built-in/file') === renderers.FileRenderer);
+  t.ok(lookup('./built-in/succinct-diagram') === renderers.SuccinctRenderer);
+  t.end();
+});


### PR DESCRIPTION
This introduces a `legacy()` function that can be used to find the
Renderer using the old `./built-in/...` paths from `formatters`.
